### PR TITLE
Added Support for Remote files

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,18 @@
   "engines": {
     "vscode": "^1.10.0"
   },
+  "contributes": {
+    "configuration": {
+      "title": "CSS Settings",
+      "properties": {
+        "css.remoteStyleSheets": {
+          "type": "array",
+          "default": [],
+          "description": "A list of remote style sheets."
+        }
+      }
+    }
+  },
   "categories": [
     "Languages",
     "Other"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -136,7 +136,6 @@ function parseRemote(url: string) {
 }
 
 function parseRemoteConfig() {
-  console.log('parse remote');
   let remoteCssConfig = vsc.workspace.getConfiguration('css');
   let urls = remoteCssConfig.get('remoteStyleSheets') as string[];
   urls.forEach(url => parseRemote(url));


### PR DESCRIPTION
This allows the user to add remote style sheets to their `.vscode/settings.json` file for project based files or to the master settings file for global based files.

This relates to issue #21 