### PR TITLE
Adds *.md support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Missing CSS support for HTML documents.
 - handlebars
 - php
 - twig
+- md
 
 ## Remote Style Sheets
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-html-css",
   "displayName": "HTML CSS Support",
   "description": "CSS support for HTML documents",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "publisher": "ecmel",
   "license": "MIT",
   "homepage": "https://github.com/ecmel/vscode-html-css",
@@ -47,7 +47,8 @@
     "onLanguage:jade",
     "onLanguage:handlebars",
     "onLanguage:php",
-    "onLanguage:twig"
+    "onLanguage:twig",
+    "onLanguage:md"
   ],
   "main": "./out/src/extension",
   "scripts": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -182,7 +182,8 @@ export function activate(context: vsc.ExtensionContext) {
     'jade',
     'handlebars',
     'php',
-    'twig'
+    'twig',
+    'md'
   ], classServer));
 
   let wp = /(-?\d*\.\d\w*)|([^\`\~\!\@\#\%\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\.\"\,\<\>\/\?\s]+)/g;
@@ -196,6 +197,7 @@ export function activate(context: vsc.ExtensionContext) {
   context.subscriptions.push(vsc.languages.setLanguageConfiguration('handlebars', { wordPattern: wp }));
   context.subscriptions.push(vsc.languages.setLanguageConfiguration('php', { wordPattern: wp }));
   context.subscriptions.push(vsc.languages.setLanguageConfiguration('twig', { wordPattern: wp }));
+  context.subscriptions.push(vsc.languages.setLanguageConfiguration('md', { wordPattern: wp }));
 
   context.subscriptions.push(vsc.workspace.onDidChangeConfiguration((e) => parseRemoteConfig()));
 }


### PR DESCRIPTION
Simple PR that mimics the changes required to support twig. It's not all too uncommon to see HTML markup inside a *.md, like a Jekyll or Ghost site. In order to leverage CSS classes throughout the project this PR enables intellisense on the classnames inside *.md files.