### PR TITLE
Support for http remote files

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "@types/mocha": "^2.2.32"
   },
   "dependencies": {
-    "vscode-languageserver-types": "3.2.0",
-    "vscode-css-languageservice": "2.0.3"
+    "request": "^2.81.0",
+    "vscode-css-languageservice": "2.0.3",
+    "vscode-languageserver-types": "3.2.0"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,8 @@ import * as lst from 'vscode-languageserver-types';
 import * as css from 'vscode-css-languageservice';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as https from 'https';
+const request = require('request');
+// import * as https from 'https';
 
 let service = css.getCSSLanguageService();
 let map: { [index: string]: vsc.CompletionItem[]; } = {};
@@ -123,16 +124,13 @@ function parse(uri: vsc.Uri): void {
 }
 
 function parseRemote(url: string) {
-  https.get(url, res => {
-    let styles = '';
-    res.on('data', d => {
-      styles += d.toString();
-    }).on('end', () => {
-      let doc = lst.TextDocument.create(url, 'css', 1, styles);
+  request(url, (err, response, body: string) => {
+    if (body.length > 0) {
+      let doc = lst.TextDocument.create(url, 'css', 1, body);
       let symbols = service.findDocumentSymbols(doc, service.parseStylesheet(doc));
       pushSymbols(url, symbols);
-    });
-  })
+    }
+  });
 }
 
 function parseRemoteConfig() {
@@ -153,7 +151,7 @@ export function activate(context: vsc.ExtensionContext) {
           parse(uris[i]);
         }
       });
-        
+
       let watcher = vsc.workspace.createFileSystemWatcher(glob);
 
       watcher.onDidCreate(function (uri: vsc.Uri) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,6 @@ import * as css from 'vscode-css-languageservice';
 import * as fs from 'fs';
 import * as path from 'path';
 const request = require('request');
-// import * as https from 'https';
 
 let service = css.getCSSLanguageService();
 let map: { [index: string]: vsc.CompletionItem[]; } = {};


### PR DESCRIPTION
The plugin currently only supports `https`, I have replace the `http` import with the `request` package which will figure out if `http` or `https` is needed in load the remote file(s).