### PR TITLE
Add trigger characters for completionItemProvider

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -196,7 +196,7 @@ export function activate(context: vsc.ExtensionContext) {
     'typescriptreact'
   ]
 
-  context.subscriptions.push(vsc.languages.registerCompletionItemProvider(langs, new ClassServer()));
+  context.subscriptions.push(vsc.languages.registerCompletionItemProvider(langs, new ClassServer(), '.', '#', '\'', '"'));
 
   let wp = /(-?\d*\.\d\w*)|([^\`\~\!\@\#\%\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\.\"\,\<\>\/\?\s]+)/g;
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -196,7 +196,7 @@ export function activate(context: vsc.ExtensionContext) {
     'typescriptreact'
   ]
 
-  context.subscriptions.push(vsc.languages.registerCompletionItemProvider(langs, new ClassServer(), '.', '#', '\'', '"'));
+  context.subscriptions.push(vsc.languages.registerCompletionItemProvider(langs, new ClassServer(), '.', '#', '\'', '"', ' '));
 
   let wp = /(-?\d*\.\d\w*)|([^\`\~\!\@\#\%\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\.\"\,\<\>\/\?\s]+)/g;
 


### PR DESCRIPTION
Currently (at least while editing .pug files) I find that completion is only triggered immediately if the cursor is at the end of a line - Otherwise, I must type '.' then type a couple more characters, then hit backspace before completion items are shown. Adding trigger characters for the completion provider solves that issue.