### PR TITLE
Fix regex for dots and hashes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,7 +44,7 @@ class ClassServer implements vsc.CompletionItemProvider {
 
   private regex = [
     /(class|id|className)=["|']([^"^']*$)/i,
-    /(\.|\#)[^\s]*$/i,
+    /(?:\.([^\s\#\.]*)$)|(?:\#([^\s\.\#]*)$)/i,
     /<style[\s\S]*>([\s\S]*)<\/style>/ig
   ];
 


### PR DESCRIPTION
Previously, a string such as ‘#some-id.some-class’ will match as ‘some-id.some-class’,
rather than just ‘some-class’ - This adjustment will match only the last substring following
either a hash or a dot, and containing neither.