### PR TITLE
Fixed Typescript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,23 +26,26 @@ Missing CSS support for HTML documents.
 - nunjucks
 - javascript
 - javascriptreact
+- typescript
+- typescriptreact
 
 ## Remote Style Sheets
 
 Remote style sheets can be specified in VS Code settings:
 
-```
+```json
 "css.remoteStyleSheets": [
   "https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css"
 ]
 ```
+
 ## Style Sheet File Extensions
 
 By default, `css` and `scss` files in the project are parsed. You may configure this in VS Code Settings
 
 Remote style sheets can be specified in VS Code settings:
 
-```
+```json
 "css.fileExtensions": [ "css", "scss"]
 ```
 
@@ -51,4 +54,5 @@ Remote style sheets can be specified in VS Code settings:
 [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=ecmel.vscode-html-css)
 
 ## Usage
+
 You can view a list of attributes via `ctrl + space`.

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "onLanguage:typescriptreact",
     "onLanguage:typescript"
   ],
-  "main": "./out/extension",
+  "main": "./out/src/extension",
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",

--- a/package.json
+++ b/package.json
@@ -60,9 +60,11 @@
     "onLanguage:md",
     "onLanguage:nunjucks",
     "onLanguage:javascript",
-    "onLanguage:javascriptreact"
+    "onLanguage:javascriptreact",
+    "onLanguage:typescriptreact",
+    "onLanguage:typescript"
   ],
-  "main": "./out/src/extension",
+  "main": "./out/extension",
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",


### PR DESCRIPTION
Added missing activationEvents that were forgotten in #60 in package.json to enable it on `typescript` an `typescriptreact`