### PR TITLE
Update to support Elixir LS 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "onLanguage:javascriptreact",
     "onLanguage:typescriptreact",
     "onLanguage:typescript",
-    "onLanguage:HTML (EEx)"
+    "onLanguage:HTML (EEx)",
+    "onLanguage:html-eex"
   ],
   "main": "./dist/extension",
   "scripts": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -194,7 +194,8 @@ export function activate(context: vsc.ExtensionContext) {
     'erb',
     'typescript',
     'typescriptreact',
-    'HTML (Eex)'
+    'HTML (Eex)',
+    'html-eex'
   ]
 
   context.subscriptions.push(vsc.languages.registerCompletionItemProvider(langs, new ClassServer(), '.', '#', '\'', '"', ' '));


### PR DESCRIPTION
Elixir's file type for .eex and .leex templates is now called `html-eex` within VS Code.