### PR TITLE
Use a configurable list to enable extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,22 +13,26 @@ Missing CSS support for HTML documents.
 
 ## Supported Languages
 
-- html
-- laravel-blade
-- razor
-- vue
-- pug
-- jade
-- handlebars
-- php
-- twig
-- md
-- nunjucks
-- javascript
-- javascriptreact
-- typescript
-- typescriptreact
-- HTML (EEx)
+Supported languages can be configured with the `css.enabledLanguages` configuration setting. By
+default the following languages are enabled:
+
+```json
+"css.enabledLanguages": [
+  "html",
+  "laravel-blade",
+  "razor",
+  "vue",
+  "pug",
+  "jade",
+  "handlebars",
+  "php",
+  "twig",
+  "nunjucks",
+  "javascriptreact",
+  "typescriptreact",
+  "HTML (EEx)"
+]
+```
 
 ## Remote Style Sheets
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-html-css",
   "displayName": "HTML CSS Support",
   "description": "CSS support for HTML documents",
-  "version": "0.2.3",
+  "version": "0.3.3",
   "publisher": "ecmel",
   "license": "MIT",
   "homepage": "https://github.com/ecmel/vscode-html-css",
@@ -31,6 +31,29 @@
             "scss"
           ],
           "description": "A list of style sheet file extensions you want the extension to look for."
+        },
+        "css.enabledLanguages": {
+          "type": "array",
+          "description": "A list of languages where suggestions are desired.",
+          "default": [
+            "html",
+            "django-html",
+            "laravel-blade",
+            "razor",
+            "vue",
+            "blade",
+            "pug",
+            "jade",
+            "handlebars",
+            "php",
+            "twig",
+            "nunjucks",
+            "javascriptreact",
+            "erb",
+            "typescriptreact",
+            "HTML (Eex)",
+            "html-eex"
+          ]
         }
       }
     }
@@ -57,12 +80,9 @@
     "onLanguage:handlebars",
     "onLanguage:php",
     "onLanguage:twig",
-    "onLanguage:md",
     "onLanguage:nunjucks",
-    "onLanguage:javascript",
     "onLanguage:javascriptreact",
     "onLanguage:typescriptreact",
-    "onLanguage:typescript",
     "onLanguage:HTML (EEx)",
     "onLanguage:html-eex"
   ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,30 +1,32 @@
-'use strict';
+"use strict";
 
 // (c) 2016-2017 Ecmel Ercan
 
-import * as vsc from 'vscode';
-import * as lst from 'vscode-languageserver-types';
-import * as css from 'vscode-css-languageservice';
-import * as fs from 'fs';
-import * as path from 'path';
-const request = require('request');
+import * as vsc from "vscode";
+import * as lst from "vscode-languageserver-types";
+import * as css from "vscode-css-languageservice";
+import * as fs from "fs";
+import * as path from "path";
+const request = require("request");
 
 let service = css.getCSSLanguageService();
-let map: { [index: string]: vsc.CompletionItem[]; } = {};
+let map: { [index: string]: vsc.CompletionItem[] } = {};
 let regex = /[\.\#]([\w-]+)/g;
 let dot = vsc.CompletionItemKind.Class;
 let hash = vsc.CompletionItemKind.Reference;
 
 class Snippet {
-
   private _document: lst.TextDocument;
   private _stylesheet: css.Stylesheet;
   private _position: lst.Position;
 
   constructor(content: string, character?: number) {
-    this._document = lst.TextDocument.create('', 'css', 1, content);
+    this._document = lst.TextDocument.create("", "css", 1, content);
     this._stylesheet = service.parseStylesheet(this._document);
-    this._position = new vsc.Position(this._document.lineCount - 1, character ? character : 0);
+    this._position = new vsc.Position(
+      this._document.lineCount - 1,
+      character ? character : 0
+    );
   }
 
   public get document(): lst.TextDocument {
@@ -41,22 +43,26 @@ class Snippet {
 }
 
 class ClassServer implements vsc.CompletionItemProvider {
-
   private regex = [
     /(class|id|className)=["|']([^"^']*$)/i,
     /(?:\.([^\s\#\.]*)$)|(?:\#([^\s\.\#]*)$)/i,
-    /<style[\s\S]*>([\s\S]*)<\/style>/ig
+    /<style[\s\S]*>([\s\S]*)<\/style>/gi,
   ];
 
-  provideCompletionItems(document: vsc.TextDocument, position: vsc.Position, token: vsc.CancellationToken): vsc.CompletionList {
+  provideCompletionItems(
+    document: vsc.TextDocument,
+    position: vsc.Position,
+    token: vsc.CancellationToken
+  ): vsc.CompletionList {
     let start = new vsc.Position(0, 0);
     let range = new vsc.Range(start, position);
     let text = document.getText(range);
 
     let tag = this.regex[0].exec(text);
     if (!tag) {
-      const textList = text.split('\n');
-      const finalLineText = textList.length > 0 ? textList[textList.length - 1] : false;
+      const textList = text.split("\n");
+      const finalLineText =
+        textList.length > 0 ? textList[textList.length - 1] : false;
       if (finalLineText) {
         tag = this.regex[1].exec(finalLineText);
       }
@@ -64,26 +70,32 @@ class ClassServer implements vsc.CompletionItemProvider {
     if (tag) {
       let internal: lst.SymbolInformation[] = [];
       let style;
-      while (style = this.regex[2].exec(document.getText())) {
+      while ((style = this.regex[2].exec(document.getText()))) {
         let snippet = new Snippet(style[1]);
-        let symbols = service.findDocumentSymbols(snippet.document, snippet.stylesheet);
+        let symbols = service.findDocumentSymbols(
+          snippet.document,
+          snippet.stylesheet
+        );
         for (let symbol of symbols) {
           internal.push(symbol);
         }
       }
-      pushSymbols('style', internal);
+      pushSymbols("style", internal);
 
-      let items: { [index: string]: vsc.CompletionItem; } = {};
+      let items: { [index: string]: vsc.CompletionItem } = {};
       for (let key in map) {
         for (let item of map[key]) {
           items[item.label] = item;
         }
       }
 
-      let id = tag[0].startsWith('id') || tag[0].startsWith('#');
+      let id = tag[0].startsWith("id") || tag[0].startsWith("#");
       let ci: vsc.CompletionItem[] = [];
       for (let item in items) {
-        if ((id && items[item].kind === hash) || !id && items[item].kind === dot) {
+        if (
+          (id && items[item].kind === hash) ||
+          (!id && items[item].kind === dot)
+        ) {
           ci.push(items[item]);
         }
       }
@@ -92,7 +104,10 @@ class ClassServer implements vsc.CompletionItemProvider {
     return null;
   }
 
-  resolveCompletionItem(item: vsc.CompletionItem, token: vsc.CancellationToken): vsc.CompletionItem {
+  resolveCompletionItem(
+    item: vsc.CompletionItem,
+    token: vsc.CancellationToken
+  ): vsc.CompletionItem {
     return null;
   }
 }
@@ -104,9 +119,9 @@ function pushSymbols(key: string, symbols: lst.SymbolInformation[]): void {
       continue;
     }
     let symbol;
-    while (symbol = regex.exec(symbols[i].name)) {
+    while ((symbol = regex.exec(symbols[i].name))) {
       let item = new vsc.CompletionItem(symbol[1]);
-      item.kind = symbol[0].startsWith('.') ? dot : hash;
+      item.kind = symbol[0].startsWith(".") ? dot : hash;
       item.detail = path.basename(key);
       ci.push(item);
     }
@@ -115,12 +130,15 @@ function pushSymbols(key: string, symbols: lst.SymbolInformation[]): void {
 }
 
 function parse(uri: vsc.Uri): void {
-  fs.readFile(uri.fsPath, 'utf8', function (err: any, data: string) {
+  fs.readFile(uri.fsPath, "utf8", function (err: any, data: string) {
     if (err) {
       delete map[uri.fsPath];
     } else {
-      let doc = lst.TextDocument.create(uri.fsPath, 'css', 1, data);
-      let symbols = service.findDocumentSymbols(doc, service.parseStylesheet(doc));
+      let doc = lst.TextDocument.create(uri.fsPath, "css", 1, data);
+      let symbols = service.findDocumentSymbols(
+        doc,
+        service.parseStylesheet(doc)
+      );
       pushSymbols(uri.fsPath, symbols);
     }
   });
@@ -129,28 +147,30 @@ function parse(uri: vsc.Uri): void {
 function parseRemote(url: string) {
   request(url, (err, response, body: string) => {
     if (body.length > 0) {
-      let doc = lst.TextDocument.create(url, 'css', 1, body);
-      let symbols = service.findDocumentSymbols(doc, service.parseStylesheet(doc));
+      let doc = lst.TextDocument.create(url, "css", 1, body);
+      let symbols = service.findDocumentSymbols(
+        doc,
+        service.parseStylesheet(doc)
+      );
       pushSymbols(url, symbols);
     }
   });
 }
 
 function parseRemoteConfig() {
-  let remoteCssConfig = vsc.workspace.getConfiguration('css');
-  let urls = remoteCssConfig.get('remoteStyleSheets') as string[];
+  let remoteCssConfig = vsc.workspace.getConfiguration("css");
+  let urls = remoteCssConfig.get("remoteStyleSheets") as string[];
   urls.forEach((url) => parseRemote(url));
 }
 
 export function activate(context: vsc.ExtensionContext) {
+  const remoteCssConfig = vsc.workspace.getConfiguration("css");
 
   if (vsc.workspace.workspaceFolders) {
-
-    const remoteCssConfig = vsc.workspace.getConfiguration('css');
-    const extensions = remoteCssConfig.get('fileExtensions') as string[];
-    extensions.forEach(ext => {
-      const glob = `**/*.${ext}`
-      vsc.workspace.findFiles(glob, '').then(function (uris: vsc.Uri[]) {
+    const extensions = remoteCssConfig.get("fileExtensions") as string[];
+    extensions.forEach((ext) => {
+      const glob = `**/*.${ext}`;
+      vsc.workspace.findFiles(glob, "").then(function (uris: vsc.Uri[]) {
         for (let i = 0; i < uris.length; i++) {
           parse(uris[i]);
         }
@@ -172,42 +192,33 @@ export function activate(context: vsc.ExtensionContext) {
     });
 
     parseRemoteConfig();
+  }
 
-  };
+  const langs = remoteCssConfig.get<string[]>("enabledLanguages");
 
-  const langs = [
-    'html',
-    'django-html',
-    'laravel-blade',
-    'razor',
-    'vue',
-    'blade',
-    'pug',
-    'jade',
-    'handlebars',
-    'php',
-    'twig',
-    'md',
-    'nunjucks',
-    'javascript',
-    'javascriptreact',
-    'erb',
-    'typescript',
-    'typescriptreact',
-    'HTML (Eex)',
-    'html-eex'
-  ]
-
-  context.subscriptions.push(vsc.languages.registerCompletionItemProvider(langs, new ClassServer(), '.', '#', '\'', '"', ' '));
+  context.subscriptions.push(
+    vsc.languages.registerCompletionItemProvider(
+      langs,
+      new ClassServer(),
+      ".",
+      "#",
+      "'",
+      '"',
+      " "
+    )
+  );
 
   let wp = /(-?\d*\.\d\w*)|([^\`\~\!\@\#\%\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\.\"\,\<\>\/\?\s]+)/g;
 
   for (let i = 1; i < langs.length; i++) {
-    context.subscriptions.push(vsc.languages.setLanguageConfiguration(langs[i], { wordPattern: wp }));
+    context.subscriptions.push(
+      vsc.languages.setLanguageConfiguration(langs[i], { wordPattern: wp })
+    );
   }
 
-  context.subscriptions.push(vsc.workspace.onDidChangeConfiguration((e) => parseRemoteConfig()));
+  context.subscriptions.push(
+    vsc.workspace.onDidChangeConfiguration((e) => parseRemoteConfig())
+  );
 }
 
-export function deactivate() {
-}
+export function deactivate() {}


### PR DESCRIPTION
Adds a configurable list to enable the extension instead of a hard coded list. Also removes Markdown, JS and TS from the default list, as CSS completions are not as helpful in those languages in general and are the source of a number of open issues. Due to this change, this also bumps the version to 0.3.0

Fixes #138