### PR TITLE
Add "Publish (ovsx)" GitHub Workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,13 @@ jobs:
           node-version: 12.x
       - run: npm install
       - run: xvfb-run -a npm test
-      - name: Publish
+      - name: Publish (vsce)
         if: success()
         run: npm run deploy
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+      - name: Publish (ovsx)
+        if: success()
+        run: npx ovsx publish
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}


### PR DESCRIPTION
Hi @ecmel!

This PR fixes https://github.com/ecmel/vscode-html-css/issues/213

It simply calls `npx ovsx publish` after publishing to the VS Code marketplace, in order to publish to Open VSX as well.

The only requirement is setting up a `OVSX_PAT` secret (you can generate one [here](https://open-vsx.org/user-settings/tokens)).