### PR TITLE
Enable your extension to run on VS Code for the web

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,9 +44,9 @@
 			}
 		},
 		"@discoveryjs/json-ext": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz",
-			"integrity": "sha512-HyYEUDeIj5rRQU2Hk5HTB2uHsbRQpF70nvMhVzi+VJR0X+xNEhjPui4/kBf3VeH/wqD28PT4sVOm8qqLjBrSZg==",
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.3.tgz",
+			"integrity": "sha512-Fxt+AfXgjMoin2maPIYzFZnQjAXjAL0PHscM5pRTtatFqB+vZxAM9tLp2Optnuw3QOQC40jTNeGYFOMvyf7v9g==",
 			"dev": true
 		},
 		"@eslint/eslintrc": {
@@ -114,9 +114,9 @@
 			"dev": true
 		},
 		"@types/eslint": {
-			"version": "7.2.6",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.6.tgz",
-			"integrity": "sha512-I+1sYH+NPQ3/tVqCeUSBwTE/0heyvtXqpIopUUArlBm0Kpocb8FbMa3AZ/ASKIFpN3rnEx932TTXDbt9OXsNDw==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz",
+			"integrity": "sha512-07XlgzX0YJUn4iG1ocY4IX9DzKSmMGUs6ESKlxWhZRaa0fatIWaHWUVapcuGa8r5HFnTqzj+4OCjd5f7EZ/i/A==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "*",
@@ -124,9 +124,9 @@
 			}
 		},
 		"@types/eslint-scope": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.0.tgz",
-			"integrity": "sha512-O/ql2+rrCUe2W2rs7wMR+GqPRcgB6UiqN5RhrR5xruFlY7l9YLMn0ZkDzjoHLeiFkR8MCQZVudUuuvQ2BLC9Qw==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.1.tgz",
+			"integrity": "sha512-SCFeogqiptms4Fg29WpOTk5nHIzfpKCemSN63ksBQYKTcXoJEmJagV+DhVmbapZzY4/5YaOV1nZwrsU79fFm1g==",
 			"dev": true,
 			"requires": {
 				"@types/eslint": "*",
@@ -134,9 +134,9 @@
 			}
 		},
 		"@types/estree": {
-			"version": "0.0.46",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
-			"integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==",
+			"version": "0.0.50",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
+			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
 			"dev": true
 		},
 		"@types/glob": {
@@ -280,170 +280,170 @@
 			"dev": true
 		},
 		"@webassemblyjs/ast": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.0.tgz",
-			"integrity": "sha512-kX2W49LWsbthrmIRMbQZuQDhGtjyqXfEmmHyEi4XWnSZtPmxY0+3anPIzsnRb45VH/J55zlOfWvZuY47aJZTJg==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
+			"integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/helper-numbers": "1.11.0",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.0"
+				"@webassemblyjs/helper-numbers": "1.11.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.1"
 			}
 		},
 		"@webassemblyjs/floating-point-hex-parser": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.0.tgz",
-			"integrity": "sha512-Q/aVYs/VnPDVYvsCBL/gSgwmfjeCb4LW8+TMrO3cSzJImgv8lxxEPM2JA5jMrivE7LSz3V+PFqtMbls3m1exDA==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
+			"integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-api-error": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.0.tgz",
-			"integrity": "sha512-baT/va95eXiXb2QflSx95QGT5ClzWpGaa8L7JnJbgzoYeaA27FCvuBXU758l+KXWRndEmUXjP0Q5fibhavIn8w==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
+			"integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-buffer": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.0.tgz",
-			"integrity": "sha512-u9HPBEl4DS+vA8qLQdEQ6N/eJQ7gT7aNvMIo8AAWvAl/xMrcOSiI2M0MAnMCy3jIFke7bEee/JwdX1nUpCtdyA==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
+			"integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-numbers": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.0.tgz",
-			"integrity": "sha512-DhRQKelIj01s5IgdsOJMKLppI+4zpmcMQ3XboFPLwCpSNH6Hqo1ritgHgD0nqHeSYqofA6aBN/NmXuGjM1jEfQ==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
+			"integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/floating-point-hex-parser": "1.11.0",
-				"@webassemblyjs/helper-api-error": "1.11.0",
+				"@webassemblyjs/floating-point-hex-parser": "1.11.1",
+				"@webassemblyjs/helper-api-error": "1.11.1",
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/helper-wasm-bytecode": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.0.tgz",
-			"integrity": "sha512-MbmhvxXExm542tWREgSFnOVo07fDpsBJg3sIl6fSp9xuu75eGz5lz31q7wTLffwL3Za7XNRCMZy210+tnsUSEA==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
+			"integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
 			"dev": true
 		},
 		"@webassemblyjs/helper-wasm-section": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.0.tgz",
-			"integrity": "sha512-3Eb88hcbfY/FCukrg6i3EH8H2UsD7x8Vy47iVJrP967A9JGqgBVL9aH71SETPx1JrGsOUVLo0c7vMCN22ytJew==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
+			"integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.0",
-				"@webassemblyjs/helper-buffer": "1.11.0",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.0",
-				"@webassemblyjs/wasm-gen": "1.11.0"
+				"@webassemblyjs/ast": "1.11.1",
+				"@webassemblyjs/helper-buffer": "1.11.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+				"@webassemblyjs/wasm-gen": "1.11.1"
 			}
 		},
 		"@webassemblyjs/ieee754": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.0.tgz",
-			"integrity": "sha512-KXzOqpcYQwAfeQ6WbF6HXo+0udBNmw0iXDmEK5sFlmQdmND+tr773Ti8/5T/M6Tl/413ArSJErATd8In3B+WBA==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
+			"integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
 			"dev": true,
 			"requires": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
 		},
 		"@webassemblyjs/leb128": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.0.tgz",
-			"integrity": "sha512-aqbsHa1mSQAbeeNcl38un6qVY++hh8OpCOzxhixSYgbRfNWcxJNJQwe2rezK9XEcssJbbWIkblaJRwGMS9zp+g==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
+			"integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
 			"dev": true,
 			"requires": {
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/utf8": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.0.tgz",
-			"integrity": "sha512-A/lclGxH6SpSLSyFowMzO/+aDEPU4hvEiooCMXQPcQFPPJaYcPQNKGOCLUySJsYJ4trbpr+Fs08n4jelkVTGVw==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
+			"integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
 			"dev": true
 		},
 		"@webassemblyjs/wasm-edit": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.0.tgz",
-			"integrity": "sha512-JHQ0damXy0G6J9ucyKVXO2j08JVJ2ntkdJlq1UTiUrIgfGMmA7Ik5VdC/L8hBK46kVJgujkBIoMtT8yVr+yVOQ==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
+			"integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.0",
-				"@webassemblyjs/helper-buffer": "1.11.0",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.0",
-				"@webassemblyjs/helper-wasm-section": "1.11.0",
-				"@webassemblyjs/wasm-gen": "1.11.0",
-				"@webassemblyjs/wasm-opt": "1.11.0",
-				"@webassemblyjs/wasm-parser": "1.11.0",
-				"@webassemblyjs/wast-printer": "1.11.0"
+				"@webassemblyjs/ast": "1.11.1",
+				"@webassemblyjs/helper-buffer": "1.11.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+				"@webassemblyjs/helper-wasm-section": "1.11.1",
+				"@webassemblyjs/wasm-gen": "1.11.1",
+				"@webassemblyjs/wasm-opt": "1.11.1",
+				"@webassemblyjs/wasm-parser": "1.11.1",
+				"@webassemblyjs/wast-printer": "1.11.1"
 			}
 		},
 		"@webassemblyjs/wasm-gen": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.0.tgz",
-			"integrity": "sha512-BEUv1aj0WptCZ9kIS30th5ILASUnAPEvE3tVMTrItnZRT9tXCLW2LEXT8ezLw59rqPP9klh9LPmpU+WmRQmCPQ==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
+			"integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.0",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.0",
-				"@webassemblyjs/ieee754": "1.11.0",
-				"@webassemblyjs/leb128": "1.11.0",
-				"@webassemblyjs/utf8": "1.11.0"
+				"@webassemblyjs/ast": "1.11.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+				"@webassemblyjs/ieee754": "1.11.1",
+				"@webassemblyjs/leb128": "1.11.1",
+				"@webassemblyjs/utf8": "1.11.1"
 			}
 		},
 		"@webassemblyjs/wasm-opt": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.0.tgz",
-			"integrity": "sha512-tHUSP5F4ywyh3hZ0+fDQuWxKx3mJiPeFufg+9gwTpYp324mPCQgnuVKwzLTZVqj0duRDovnPaZqDwoyhIO8kYg==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
+			"integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.0",
-				"@webassemblyjs/helper-buffer": "1.11.0",
-				"@webassemblyjs/wasm-gen": "1.11.0",
-				"@webassemblyjs/wasm-parser": "1.11.0"
+				"@webassemblyjs/ast": "1.11.1",
+				"@webassemblyjs/helper-buffer": "1.11.1",
+				"@webassemblyjs/wasm-gen": "1.11.1",
+				"@webassemblyjs/wasm-parser": "1.11.1"
 			}
 		},
 		"@webassemblyjs/wasm-parser": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.0.tgz",
-			"integrity": "sha512-6L285Sgu9gphrcpDXINvm0M9BskznnzJTE7gYkjDbxET28shDqp27wpruyx3C2S/dvEwiigBwLA1cz7lNUi0kw==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
+			"integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.0",
-				"@webassemblyjs/helper-api-error": "1.11.0",
-				"@webassemblyjs/helper-wasm-bytecode": "1.11.0",
-				"@webassemblyjs/ieee754": "1.11.0",
-				"@webassemblyjs/leb128": "1.11.0",
-				"@webassemblyjs/utf8": "1.11.0"
+				"@webassemblyjs/ast": "1.11.1",
+				"@webassemblyjs/helper-api-error": "1.11.1",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+				"@webassemblyjs/ieee754": "1.11.1",
+				"@webassemblyjs/leb128": "1.11.1",
+				"@webassemblyjs/utf8": "1.11.1"
 			}
 		},
 		"@webassemblyjs/wast-printer": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.0.tgz",
-			"integrity": "sha512-Fg5OX46pRdTgB7rKIUojkh9vXaVN6sGYCnEiJN1GYkb0RPwShZXp6KTDqmoMdQPKhcroOXh3fEzmkWmCYaKYhQ==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
+			"integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
 			"dev": true,
 			"requires": {
-				"@webassemblyjs/ast": "1.11.0",
+				"@webassemblyjs/ast": "1.11.1",
 				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webpack-cli/configtest": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.1.tgz",
-			"integrity": "sha512-B+4uBUYhpzDXmwuo3V9yBH6cISwxEI4J+NO5ggDaGEEHb0osY/R7MzeKc0bHURXQuZjMM4qD+bSJCKIuI3eNBQ==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.4.tgz",
+			"integrity": "sha512-cs3XLy+UcxiP6bj0A6u7MLLuwdXJ1c3Dtc0RkKg+wiI1g/Ti1om8+/2hc2A2B60NbBNAbMgyBMHvyymWm/j4wQ==",
 			"dev": true
 		},
 		"@webpack-cli/info": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.2.2.tgz",
-			"integrity": "sha512-5U9kUJHnwU+FhKH4PWGZuBC1hTEPYyxGSL5jjoBI96Gx8qcYJGOikpiIpFoTq8mmgX3im2zAo2wanv/alD74KQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.3.0.tgz",
+			"integrity": "sha512-ASiVB3t9LOKHs5DyVUcxpraBXDOKubYu/ihHhU+t1UPpxsivg6Od2E2qU4gJCekfEddzRBzHhzA/Acyw/mlK/w==",
 			"dev": true,
 			"requires": {
 				"envinfo": "^7.7.3"
 			}
 		},
 		"@webpack-cli/serve": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.3.0.tgz",
-			"integrity": "sha512-k2p2VrONcYVX1wRRrf0f3X2VGltLWcv+JzXRBDmvCxGlCeESx4OXw91TsWeKOkp784uNoVQo313vxJFHXPPwfw==",
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.5.2.tgz",
+			"integrity": "sha512-vgJ5OLWadI8aKjDlOH3rb+dYyPd2GTZuQC/Tihjct6F9GpXGZINo3Y/IVuZVTM1eDQB+/AOsjPUWH/WySDaXvw==",
 			"dev": true
 		},
 		"@xtuc/ieee754": {
@@ -462,6 +462,12 @@
 			"version": "7.4.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
 			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+			"dev": true
+		},
+		"acorn-import-assertions": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.7.6.tgz",
+			"integrity": "sha512-FlVvVFA1TX6l3lp8VjDnYYq7R1nyW6x3svAt4nDgrWQ9SBaSh9CnbwgSUTasgfNfOG5HlM1ehugCvM+hjo56LA==",
 			"dev": true
 		},
 		"acorn-jsx": {
@@ -639,16 +645,24 @@
 			"dev": true
 		},
 		"browserslist": {
-			"version": "4.16.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-			"integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+			"version": "4.16.8",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
+			"integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001181",
-				"colorette": "^1.2.1",
-				"electron-to-chromium": "^1.3.649",
+				"caniuse-lite": "^1.0.30001251",
+				"colorette": "^1.3.0",
+				"electron-to-chromium": "^1.3.811",
 				"escalade": "^3.1.1",
-				"node-releases": "^1.1.70"
+				"node-releases": "^1.1.75"
+			},
+			"dependencies": {
+				"colorette": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
+					"integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
+					"dev": true
+				}
 			}
 		},
 		"buffer-crc32": {
@@ -658,9 +672,9 @@
 			"dev": true
 		},
 		"buffer-from": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"dev": true
 		},
 		"buffer-indexof-polyfill": {
@@ -688,9 +702,9 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001185",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001185.tgz",
-			"integrity": "sha512-Fpi4kVNtNvJ15H0F6vwmXtb3tukv3Zg3qhKkOGUq7KJ1J6b9kf4dnNgtEAFXhRsJo0gNj9W60+wBvn0JcTvdTg==",
+			"version": "1.0.30001251",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
+			"integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
 			"dev": true
 		},
 		"chainsaw": {
@@ -782,13 +796,10 @@
 			}
 		},
 		"chrome-trace-event": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
-			"integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
-			"dev": true,
-			"requires": {
-				"tslib": "^1.9.0"
-			}
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+			"dev": true
 		},
 		"cliui": {
 			"version": "5.0.0",
@@ -845,9 +856,9 @@
 			"dev": true
 		},
 		"colorette": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-			"integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
+			"integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
 			"dev": true
 		},
 		"combined-stream": {
@@ -1021,9 +1032,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.657",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.657.tgz",
-			"integrity": "sha512-/9ROOyvEflEbaZFUeGofD+Tqs/WynbSTbNgNF+/TJJxH1ePD/e6VjZlDJpW3FFFd3nj5l3Hd8ki2vRwy+gyRFw==",
+			"version": "1.3.813",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.813.tgz",
+			"integrity": "sha512-YcSRImHt6JZZ2sSuQ4Bzajtk98igQ0iKkksqlzZLzbh4p0OIyJRSvUbsgqfcR8txdfsoYCc4ym306t4p2kP/aw==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -1065,9 +1076,9 @@
 			"dev": true
 		},
 		"envinfo": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.7.4.tgz",
-			"integrity": "sha512-TQXTYFVVwwluWSFis6K2XKxgrD22jEv0FTuLCQI+OjH7rn93+iY0fSSFM5lrSxFY+H1+B0/cvvlamr3UsBivdQ==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
+			"integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
 			"dev": true
 		},
 		"errno": {
@@ -1080,9 +1091,9 @@
 			}
 		},
 		"es-module-lexer": {
-			"version": "0.3.26",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.3.26.tgz",
-			"integrity": "sha512-Va0Q/xqtrss45hWzP8CZJwzGSZJjDM5/MJRE3IXXnUCcVLElR9BRaE9F62BopysASyc4nM3uwhSW7FFB9nlWAA==",
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.7.1.tgz",
+			"integrity": "sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw==",
 			"dev": true
 		},
 		"escalade": {
@@ -1255,15 +1266,15 @@
 			"dev": true
 		},
 		"events": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
-			"integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
 			"dev": true
 		},
 		"execa": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
-			"integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
 			"dev": true,
 			"requires": {
 				"cross-spawn": "^7.0.3",
@@ -1449,9 +1460,9 @@
 			"dev": true
 		},
 		"get-stream": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
-			"integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
 			"dev": true
 		},
 		"glob": {
@@ -1642,9 +1653,9 @@
 			}
 		},
 		"is-core-module": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
+			"integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -1693,9 +1704,9 @@
 			}
 		},
 		"is-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-			"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
 			"dev": true
 		},
 		"isarray": {
@@ -1717,14 +1728,14 @@
 			"dev": true
 		},
 		"jest-worker": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
-			"integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+			"version": "27.0.6",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
+			"integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
 				"merge-stream": "^2.0.0",
-				"supports-color": "^7.0.0"
+				"supports-color": "^8.0.0"
 			},
 			"dependencies": {
 				"has-flag": {
@@ -1734,9 +1745,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"version": "8.1.1",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+					"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -2117,9 +2128,9 @@
 			"dev": true
 		},
 		"node-releases": {
-			"version": "1.1.70",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.70.tgz",
-			"integrity": "sha512-Slf2s69+2/uAD79pVVQo8uSiC34+g8GWY8UH2Qtqv34ZfhYrxpYpfzs9Js9d6O0mbDmALuxaTlplnBTnSELcrw==",
+			"version": "1.1.75",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+			"integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
 			"dev": true
 		},
 		"normalize-path": {
@@ -2271,6 +2282,12 @@
 				"parse5": "^6.0.1"
 			}
 		},
+		"path-browserify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+			"integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+			"dev": true
+		},
 		"path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2290,9 +2307,9 @@
 			"dev": true
 		},
 		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true
 		},
 		"path-type": {
@@ -2367,6 +2384,12 @@
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"dev": true
 		},
+		"process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+			"dev": true
+		},
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -2433,9 +2456,9 @@
 			}
 		},
 		"rechoir": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.0.tgz",
-			"integrity": "sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==",
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
+			"integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
 			"dev": true,
 			"requires": {
 				"resolve": "^1.9.0"
@@ -2466,12 +2489,12 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.19.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-			"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
 			"dev": true,
 			"requires": {
-				"is-core-module": "^2.1.0",
+				"is-core-module": "^2.2.0",
 				"path-parse": "^1.0.6"
 			}
 		},
@@ -2526,14 +2549,22 @@
 			"dev": true
 		},
 		"schema-utils": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
-			"integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+			"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
 			"dev": true,
 			"requires": {
-				"@types/json-schema": "^7.0.6",
+				"@types/json-schema": "^7.0.8",
 				"ajv": "^6.12.5",
 				"ajv-keywords": "^3.5.2"
+			},
+			"dependencies": {
+				"@types/json-schema": {
+					"version": "7.0.9",
+					"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+					"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+					"dev": true
+				}
 			}
 		},
 		"semver": {
@@ -2644,12 +2675,6 @@
 					"dev": true
 				}
 			}
-		},
-		"source-list-map": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-			"integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
-			"dev": true
 		},
 		"source-map": {
 			"version": "0.6.1",
@@ -2810,9 +2835,9 @@
 			"dev": true
 		},
 		"terser": {
-			"version": "5.5.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.5.1.tgz",
-			"integrity": "sha512-6VGWZNVP2KTUcltUQJ25TtNjx/XgdDsBDKGt8nN0MpydU36LmbPPcMBd2kmtZNNGVVDLg44k7GKeHHj+4zPIBQ==",
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.7.1.tgz",
+			"integrity": "sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.20.0",
@@ -2829,17 +2854,28 @@
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.1.1.tgz",
-			"integrity": "sha512-5XNNXZiR8YO6X6KhSGXfY0QrGrCRlSwAEjIIrlRQR4W8nP69TaJUlh3bkuac6zzgspiGPfKEHcY295MMVExl5Q==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.1.4.tgz",
+			"integrity": "sha512-C2WkFwstHDhVEmsmlCxrXUtVklS+Ir1A7twrYzrDrQQOIMOaVAYykaoo/Aq1K0QRkMoY2hhvDQY1cm4jnIMFwA==",
 			"dev": true,
 			"requires": {
-				"jest-worker": "^26.6.2",
+				"jest-worker": "^27.0.2",
 				"p-limit": "^3.1.0",
 				"schema-utils": "^3.0.0",
-				"serialize-javascript": "^5.0.1",
+				"serialize-javascript": "^6.0.0",
 				"source-map": "^0.6.1",
-				"terser": "^5.5.1"
+				"terser": "^5.7.0"
+			},
+			"dependencies": {
+				"serialize-javascript": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+					"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+					"dev": true,
+					"requires": {
+						"randombytes": "^2.1.0"
+					}
+				}
 			}
 		},
 		"text-table": {
@@ -2873,9 +2909,9 @@
 			"dev": true
 		},
 		"ts-loader": {
-			"version": "8.0.15",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.0.15.tgz",
-			"integrity": "sha512-WYXfCEglgUPU6adGcx6I9DsMwSxYFU99rzteIEoZKDQn4IMbe4KpO934zRkwSOFcwEzh+gx/RaH8hhgoCAfF9w==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.3.0.tgz",
+			"integrity": "sha512-MgGly4I6cStsJy27ViE32UoqxPTN9Xly4anxxVyaIWR+9BGxboV4EyJBGfR3RePV7Ksjj3rHmPZJeIt+7o4Vag==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.1.0",
@@ -3060,9 +3096,9 @@
 			}
 		},
 		"watchpack": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.1.1.tgz",
-			"integrity": "sha512-Oo7LXCmc1eE1AjyuSBmtC3+Wy4HcV8PxWh2kP6fOl8yTlNS7r0K9l1ao2lrrUza7V39Y3D/BbJgY8VeSlc5JKw==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
+			"integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
 			"dev": true,
 			"requires": {
 				"glob-to-regexp": "^0.4.1",
@@ -3070,22 +3106,23 @@
 			}
 		},
 		"webpack": {
-			"version": "5.21.2",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.21.2.tgz",
-			"integrity": "sha512-xHflCenx+AM4uWKX71SWHhxml5aMXdy2tu/vdi4lClm7PADKxlyDAFFN1rEFzNV0MAoPpHtBeJnl/+K6F4QBPg==",
+			"version": "5.51.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.51.1.tgz",
+			"integrity": "sha512-xsn3lwqEKoFvqn4JQggPSRxE4dhsRcysWTqYABAZlmavcoTmwlOb9b1N36Inbt/eIispSkuHa80/FJkDTPos1A==",
 			"dev": true,
 			"requires": {
 				"@types/eslint-scope": "^3.7.0",
-				"@types/estree": "^0.0.46",
-				"@webassemblyjs/ast": "1.11.0",
-				"@webassemblyjs/wasm-edit": "1.11.0",
-				"@webassemblyjs/wasm-parser": "1.11.0",
-				"acorn": "^8.0.4",
+				"@types/estree": "^0.0.50",
+				"@webassemblyjs/ast": "1.11.1",
+				"@webassemblyjs/wasm-edit": "1.11.1",
+				"@webassemblyjs/wasm-parser": "1.11.1",
+				"acorn": "^8.4.1",
+				"acorn-import-assertions": "^1.7.6",
 				"browserslist": "^4.14.5",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.7.0",
-				"es-module-lexer": "^0.3.26",
-				"eslint-scope": "^5.1.1",
+				"enhanced-resolve": "^5.8.0",
+				"es-module-lexer": "^0.7.1",
+				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.2.4",
@@ -3093,23 +3130,23 @@
 				"loader-runner": "^4.2.0",
 				"mime-types": "^2.1.27",
 				"neo-async": "^2.6.2",
-				"schema-utils": "^3.0.0",
+				"schema-utils": "^3.1.0",
 				"tapable": "^2.1.1",
-				"terser-webpack-plugin": "^5.1.1",
-				"watchpack": "^2.0.0",
-				"webpack-sources": "^2.1.1"
+				"terser-webpack-plugin": "^5.1.3",
+				"watchpack": "^2.2.0",
+				"webpack-sources": "^3.2.0"
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "8.0.5",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.5.tgz",
-					"integrity": "sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg==",
+					"version": "8.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
+					"integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
 					"dev": true
 				},
 				"enhanced-resolve": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.7.0.tgz",
-					"integrity": "sha512-6njwt/NsZFUKhM6j9U8hzVyD4E4r0x7NQzhTCbcWOJ0IQjNSAoalWmb0AE51Wn+fwan5qVESWi7t2ToBxs9vrw==",
+					"version": "5.8.2",
+					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz",
+					"integrity": "sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.2.4",
@@ -3125,18 +3162,17 @@
 			}
 		},
 		"webpack-cli": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.5.0.tgz",
-			"integrity": "sha512-wXg/ef6Ibstl2f50mnkcHblRPN/P9J4Nlod5Hg9HGFgSeF8rsqDGHJeVe4aR26q9l62TUJi6vmvC2Qz96YJw1Q==",
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.8.0.tgz",
+			"integrity": "sha512-+iBSWsX16uVna5aAYN6/wjhJy1q/GKk4KjKvfg90/6hykCTSgozbfz5iRgDTSJt/LgSbYxdBX3KBHeobIs+ZEw==",
 			"dev": true,
 			"requires": {
 				"@discoveryjs/json-ext": "^0.5.0",
-				"@webpack-cli/configtest": "^1.0.1",
-				"@webpack-cli/info": "^1.2.2",
-				"@webpack-cli/serve": "^1.3.0",
+				"@webpack-cli/configtest": "^1.0.4",
+				"@webpack-cli/info": "^1.3.0",
+				"@webpack-cli/serve": "^1.5.2",
 				"colorette": "^1.2.1",
 				"commander": "^7.0.0",
-				"enquirer": "^2.3.6",
 				"execa": "^5.0.0",
 				"fastest-levenshtein": "^1.0.12",
 				"import-local": "^3.0.2",
@@ -3147,17 +3183,17 @@
 			},
 			"dependencies": {
 				"commander": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-7.0.0.tgz",
-					"integrity": "sha512-ovx/7NkTrnPuIV8sqk/GjUIIM1+iUQeqA3ye2VNpq9sVoiZsooObWlQy+OPWGI17GDaEoybuAGJm6U8yC077BA==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+					"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
 					"dev": true
 				}
 			}
 		},
 		"webpack-merge": {
-			"version": "5.7.3",
-			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.7.3.tgz",
-			"integrity": "sha512-6/JUQv0ELQ1igjGDzHkXbVDRxkfA57Zw7PfiupdLFJYrgFqY5ZP8xxbpp2lU3EPwYx89ht5Z/aDkD40hFCm5AA==",
+			"version": "5.8.0",
+			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+			"integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
 			"dev": true,
 			"requires": {
 				"clone-deep": "^4.0.1",
@@ -3165,14 +3201,10 @@
 			}
 		},
 		"webpack-sources": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.2.0.tgz",
-			"integrity": "sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==",
-			"dev": true,
-			"requires": {
-				"source-list-map": "^2.0.1",
-				"source-map": "^0.6.1"
-			}
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.0.tgz",
+			"integrity": "sha512-fahN08Et7P9trej8xz/Z7eRu8ltyiygEo/hnRi9KqBUs80KeDcnf96ZJo++ewWd84fEf3xSX9bp4ZS9hbw0OBw==",
+			"dev": true
 		},
 		"which": {
 			"version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -81,24 +81,26 @@
 		"deploy": "vsce publish"
 	},
 	"devDependencies": {
-		"@types/vscode": "^1.53.0",
+		"@types/css-tree": "^1.0.5",
 		"@types/glob": "^7.1.3",
 		"@types/mocha": "^8.0.4",
 		"@types/node": "^12.11.7",
-		"eslint": "^7.19.0",
+		"@types/node-fetch": "^2.5.8",
+		"@types/vscode": "^1.53.0",
 		"@typescript-eslint/eslint-plugin": "^4.14.1",
 		"@typescript-eslint/parser": "^4.14.1",
+		"css-tree": "^1.1.2",
+		"eslint": "^7.19.0",
 		"glob": "^7.1.6",
 		"mocha": "^8.2.1",
-		"typescript": "^4.1.3",
-		"vscode-test": "^1.5.0",
-		"ts-loader": "^8.0.14",
-		"webpack": "^5.19.0",
-		"webpack-cli": "^4.4.0",
-		"@types/css-tree": "^1.0.5",
-		"@types/node-fetch": "^2.5.8",
-		"css-tree": "^1.1.2",
 		"node-fetch": "^2.6.1",
-		"vsce": "^1.85.0"
+		"path-browserify": "^1.0.1",
+		"process": "^0.11.10",
+		"ts-loader": "^8.3.0",
+		"typescript": "^4.1.3",
+		"vsce": "^1.85.0",
+		"vscode-test": "^1.5.0",
+		"webpack": "^5.51.1",
+		"webpack-cli": "^4.8.0"
 	}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,18 +3,12 @@
 "use strict";
 
 const path = require("path");
+const webpack = require("webpack");
 
 /**@type {import('webpack').Configuration}*/
-const config = {
-    target: "node",
+const baseConfig = {
     mode: "none",
-
     entry: "./src/extension.ts",
-    output: {
-        path: path.resolve(__dirname, "dist"),
-        filename: "extension.js",
-        libraryTarget: "commonjs2"
-    },
     devtool: "nosources-source-map",
     externals: {
         vscode: "commonjs vscode"
@@ -36,4 +30,35 @@ const config = {
         ]
     }
 };
-module.exports = config;
+
+const nodeConfig = {
+    ...baseConfig,
+    target: "node",
+    output: {
+        path: path.resolve(__dirname, "dist"),
+        filename: "extension.js",
+        libraryTarget: "commonjs2"
+    }
+};
+
+const webConfig = {
+    ...baseConfig,
+    target: "webworker",
+    output: {
+        path: path.resolve(__dirname, "dist"),
+        filename: "extension-web.js",
+        libraryTarget: "commonjs2"
+    },
+    resolve: {
+        fallback: {
+            "path": require.resolve("path-browserify")
+        }
+    },
+    plugins: [
+		new webpack.ProvidePlugin({
+			process: "process/browser",
+		})
+	]
+};
+
+module.exports = [ nodeConfig, webConfig ];


### PR DESCRIPTION
Hey @ecmel! 👋

I'm part of the VS Code team and we recently launched VS Code for the web with [github.dev](https://docs.github.com/en/codespaces/developing-in-codespaces/web-based-editor)! You can read the full guide for extension authors creating and migrating extensions here: [Web Extensions
](https://code.visualstudio.com/api/extension-guides/web-extensions)

In hopes to help you migrate I helped make the changes necessary to make your extensions work on the web.

The changes I made:
- Modify webpack bundling for both a node environment friendly and a web friendly extension
- Add and update dependencies for web bundling
- Add fallback for node library `path` with `path-browsersify`
- Add the `browser` entry point to your `package.json` to link to the web-friendly compiled extension