### PR TITLE
Update Regex in Parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-html-css",
   "displayName": "HTML CSS Support",
   "description": "CSS Intellisense for HTML",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "license": "MIT",
   "publisher": "ecmel",
   "author": {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -20,7 +20,7 @@ export interface Style {
 
 export function parse(text: string) {
   const selector =
-    /([.#])(-?[_a-zA-Z]+[_a-zA-Z0-9-]*)(?=[#.,()\s\[\]\^:*"'>=_a-zA-Z0-9-]*{[^}]*})/g;
+    /([.#])(-?[_a-zA-Z]+[\\!+_a-zA-Z0-9-]*)(?=[#.,()\s\[\]\^:*"'>=_a-zA-Z0-9-]*{[^}]*})/g;
   const styles: Style[] = [];
   const lc = lineColumn(text, { origin: 0 });
   let match,
@@ -40,7 +40,7 @@ export function parse(text: string) {
       line,
       col,
       type: match[1] as StyleType,
-      selector: match[2],
+      selector: match[2].replaceAll("\\", ''),
     });
   }
   return styles;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2021",
     "module": "ES2020",
     "moduleResolution": "Bundler",
     "isolatedModules": true,


### PR DESCRIPTION
- Updated the regex to match `\` and `!` in class names.
- Added logic to remove escape characters `\` from the selector.
 
This change ensures that a string like `.some-block-\!-some-identifier` will match as `some-block-!-some-identifier`.