### PR TITLE
Fix completion not working for non-HTML files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,7 +38,7 @@ async function validate(
 
 export function activate(context: ExtensionContext) {
   context.subscriptions.push(
-    languages.registerCompletionItemProvider(enabledLanguages, provider),
+    languages.registerCompletionItemProvider(enabledLanguages, provider, " "),
     languages.registerDefinitionProvider(enabledLanguages, provider),
     workspace.onDidSaveTextDocument(async (document) => {
       invalidate(document.uri.toString());


### PR DESCRIPTION
When adding a new file type to "css.enabledLanguages". Ex. 

```json
"css.enabledLanguages": [
    "vue",
    "html"
]
```

Auto completion only trigger outside HTML attributes . Ex.

```vue
<template>
    <a class="text-link"  | ></a>
</template>
```

It will not trigger within HTML attributes.
(Only works when Vue language extensions are not installed.)

```html
<template>
    <a class="text-link | " ></a>
</template>
```