### PR TITLE
Fix the issue where document.getWordRangeAtPosition() returns incorre…

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-html-css",
   "displayName": "HTML CSS Support",
   "description": "CSS Intellisense for HTML",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "license": "MIT",
   "publisher": "ecmel",
   "author": {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -129,8 +129,8 @@ export class Provider implements CompletionItemProvider, DefinitionProvider {
     position: Position,
     type: StyleType
   ) {
-    const map = await this.getCompletionMap(document, type);
     const range = document.getWordRangeAtPosition(position, this.wordRange);
+    const map = await this.getCompletionMap(document, type);
     const items = [];
 
     for (const item of map.values()) {
@@ -164,8 +164,8 @@ export class Provider implements CompletionItemProvider, DefinitionProvider {
   }
 
   private async getDefinitions(document: TextDocument, position: Position) {
-    const styles = await this.getStyles(document);
     const range = document.getWordRangeAtPosition(position, this.wordRange);
+    const styles = await this.getStyles(document);
     const selector = document.getText(range);
     const locations: Location[] = [];
 


### PR DESCRIPTION
Fix the issue where `document.getWordRangeAtPosition()` retrieves incorrect positions due to inputting other content before the results from `getStyles()` are returned.

This can fix the issue where quickly typing a class name causes the completion to incorrectly overwrite content outside of the class attribute. For example:
Expected result:
`<h class="test100"></h>`
Actual result:
`<h class=" test100></h>`
`<h class=" test100</h>`
This situation becomes particularly noticeable when `editor.quickSuggestions.string` is enabled. The faster you type or the larger the css file, the more characters are overwritten.

This fix can resolve issue #278.
You can reproduce the issue using the files in this zip archive.
[html-class-test.zip](https://github.com/user-attachments/files/18106619/html-class-test.zip)
